### PR TITLE
Keep midpoint on the line

### DIFF
--- a/src/lib/create_midpoint.js
+++ b/src/lib/create_midpoint.js
@@ -12,10 +12,16 @@ export default function(parent, startVertex, endVertex) {
     endCoord[1] < Constants.LAT_RENDERED_MIN) {
     return null;
   }
-
+  function mercatorYfromLat(lat) {
+    return (180 - 180 / Math.PI * Math.log(Math.tan(Math.PI / 4 + lat * Math.PI / 360))) / 360;
+  }
+  function latFromMercatorY(y) {
+    const y2 = 180 - y * 360;
+    return 360 / Math.PI * Math.atan(Math.exp(y2 * Math.PI / 180)) - 90;
+  }
   const mid = {
     lng: (startCoord[0] + endCoord[0]) / 2,
-    lat: (startCoord[1] + endCoord[1]) / 2
+    lat: latFromMercatorY((mercatorYfromLat(startCoord[1]) + mercatorYfromLat(endCoord[1])) / 2)
   };
 
   return {


### PR DESCRIPTION
With the average of Mercator coordinates of the two endpoints, the middle points were drawn off from the line.

By project/unproject the Mercator latitudes to and from screen space, the screen location for midpoints would be fixed onto the line.